### PR TITLE
Automatic task and cdn configuration 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,18 +5,11 @@
 
 module.exports = function(grunt){
 
-    // 配置项目的路径
-    var pathObj = {
-        demoProjectA:'demoProjectA',
-        demoProjectB:'demoProjectB/mobile',
-        demoProjectC:'demoProjectC'
-    }
+    // 配置cdn前缀
+    var cdnPrefix = 'http://cdn.example.cn/'
 
-    // 配置项目需要替换的静态文件的cdn地址前缀，如果无需替换，则没有对应字段
-    // 示例中，只有demoProjectC项目需要替换
-    var cdnPrefixObj = {
-        demoProjectC:'http://7xjwxy.com2.z0.glb.qiniucdn.com/peon/demoProjectC/'
-    }
+    // 配置构造cdn路径时，需要被忽略的路径前缀
+    var ignoreCdnPathPrefix = ''
 
     // 配置是否记录md5重命名的log
     var md5RenameMap = false
@@ -26,6 +19,30 @@ module.exports = function(grunt){
         start:'peon delete start',
         end:'peon delete end'
     }
+
+    var pathObj = {}
+    var cdnPrefixObj = {}
+    process.argv.forEach(function(key, i) {
+        if (i <= 1) return true
+        var isOption = false
+        grunt.option.flags().forEach(function(obj) {
+            if (obj.indexOf(key) == 0) {
+                isOption = true
+                return false
+            }
+        })
+        if (!isOption) {
+            pathObj[key] = key
+            grunt.log.write("Creating user-specified task: " + pathObj[key] + "...").ok()
+            // cdn配置代码
+            // var cdnPath = key
+            // if (key.indexOf(ignoreCdnPathPrefix) == 0) {
+            //     cdnPath = key.substr(ignoreCdnPathPrefix.length)
+            // }
+            // cdnPrefixObj[key] = cdnPrefix + cdnPath
+            // grunt.log.write("Creating CDN path: " + cdnPrefixObj[key] + "...").ok()
+        }
+    })
 
     var deleteDebugCodeReg = {
         html:new RegExp('<\\!-- '+deleteDebugCodeMark.start+' -->(.|\\s)*?<\\!-- '+deleteDebugCodeMark.end+' -->', 'g'),

--- a/README.md
+++ b/README.md
@@ -70,17 +70,7 @@ started](http://gruntjs.com/getting-started)
 
 ### 在 `Gruntfile.js` 中添加项目
 
-打开 `Gruntfile.js` 在最顶部的 `pathObj`
-对象中，加上你的项目名（key）和路径（value），添加完以后的例子：
-
-    var pathObj = {
-        demoProjectA:'demoProjectA',
-        demoProjectB:'demoProjectB/mobile',
-        demoProjectC:'demoProjectC',
-        myProject:'myProject'
-    }
-
-你也可以直接修改demoProjectA或demoProjectB所在行
+`Gruntfile.js`支持根据命令行自动加入项目。此处无需人工干预。
 
 ### 运行
 
@@ -92,9 +82,12 @@ started](http://gruntjs.com/getting-started)
 ### 将静态文件地址替换为CDN链接（给地址添加前缀）
 
 在 `Gruntfile.js`
-中添加项目时，如果该项目需要将静态文件置于一个特殊的CDN服务器（即需要为修改代码中的静态文件增加一个域名前缀），则需要在配置
-`pathObj` 中的字段的同时，配置 `cdnPrefixObj` ，字段名与 `pathObj`
-中的相同，值为对应需要为静态文件添加的前缀
+中添加项目时，如果该项目需要将静态文件置于一个特殊的CDN服务器（即需要为修改代码中的静态文件增加一个域名前缀），则搜索
+`cdn配置代码`，然后打开注释并修改相关代码。cdn的域名前缀为cdnPrefix。默认为在配置`pathObj` 中的字段的同时，配置 
+`cdnPrefixObj` ，字段名与 `pathObj`中的相同，值为对应需要为静态文件添加的前缀
+
+有的时候需要忽略一部分pathObj中的路径。比如pathObj为git/example_dir，但是只希望用example_dir配置cdn路径，
+于是配置ignoreCdnPathPrefix为`git/`
 
     var cdnPrefixObj = {
         demoProjectC:'http://7xjwxy.com2.z0.glb.qiniucdn.com/peon/demoProjectC/', // 这是我的示例，请无视具体地址

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ started](http://gruntjs.com/getting-started)
 
 在 `Gruntfile.js`
 中添加项目时，如果该项目需要将静态文件置于一个特殊的CDN服务器（即需要为修改代码中的静态文件增加一个域名前缀），则搜索
-`cdn配置代码`，然后打开注释并修改相关代码。cdn的域名前缀为cdnPrefix。默认为在配置`pathObj` 中的字段的同时，配置 
+`cdn配置代码`，然后打开注释并修改相关代码。cdn的域名前缀为`cdnPrefix`。默认为在配置`pathObj` 中的字段的同时，配置 
 `cdnPrefixObj` ，字段名与 `pathObj`中的相同，值为对应需要为静态文件添加的前缀
 
-有的时候需要忽略一部分pathObj中的路径。比如pathObj为git/example_dir，但是只希望用example_dir配置cdn路径，
-于是配置ignoreCdnPathPrefix为`git/`
+有的时候需要忽略一部分`pathObj`中的路径。比如`pathObj`为`git/example_dir`，但是只希望用`example_dir`配置cdn路径，
+于是配置`ignoreCdnPathPrefix`为`git/`
 
     var cdnPrefixObj = {
         demoProjectC:'http://7xjwxy.com2.z0.glb.qiniucdn.com/peon/demoProjectC/', // 这是我的示例，请无视具体地址


### PR DESCRIPTION
In previous edition, users need to configure the cdn paths and tasks manually. This fork aims at automatically creating tasks and cdn configuration according to the command line. For example, in order to run project A, users do not take trouble to modify Gruntfile.js. Instead, they just type `grunt A` in the command line and project A will be compiled.
